### PR TITLE
Incorrect calculate $this->_hidden property

### DIFF
--- a/widgets/Select2.php
+++ b/widgets/Select2.php
@@ -89,7 +89,7 @@ class Select2 extends InputWidget
         $this->_hidden = !empty($this->pluginOptions['data']) ||
             !empty($this->pluginOptions['query']) ||
             !empty($this->pluginOptions['ajax']) ||
-            !empty($this->pluginOptions['tags']);
+            isset($this->pluginOptions['tags']);
         if (!isset($this->data) && !$this->_hidden) {
             throw new InvalidConfigException("No 'data' source found for Select2. Either the 'data' property must be set OR one of 'data', 'query', 'ajax', or 'tags' must be set within 'pluginOptions'.");
         }


### PR DESCRIPTION
When we want use select2 for tags -> initially "tags" property may be empty.
