### PR TITLE
Missing semicolon

### DIFF
--- a/widgets/InputWidget.php
+++ b/widgets/InputWidget.php
@@ -212,7 +212,7 @@ class InputWidget extends \yii\widgets\InputWidget
             if ($callback != null) {
                 $script = "\$.when({$script}).done({$callback})";
             }
-            $view->registerJs($script);
+            $view->registerJs("$script;");
         }
 
         if (!empty($this->pluginEvents)) {


### PR DESCRIPTION
Without this semicolon I had issues with the generated JS code. For instance, I got this code:

$.when(jQuery('#companyform-categories').select2(select2_81a1c529)).done(function(){
    [...]
})
(function () {
    [...]
