### PR TITLE
fix empty element on depdrop with select2

### DIFF
--- a/widgets/DepDrop.php
+++ b/widgets/DepDrop.php
@@ -67,7 +67,7 @@ class DepDrop extends InputWidget
         if ($this->type === self::TYPE_SELECT2 &&
             (!empty($this->options['placeholder']) || !empty($this->select2Options['options']['placeholder']))
         ) {
-            $this->pluginOptions['placeholder'] = '';
+            $this->pluginOptions['placeholder'] = false;
         } elseif ($this->type === self::TYPE_SELECT2 && !empty($this->pluginOptions['placeholder']) && $this->pluginOptions['placeholder'] !== false) {
             $this->options['placeholder'] = $this->pluginOptions['placeholder'];
             $this->pluginOptions['placeholder'] = '';


### PR DESCRIPTION
Hi!
If I use depdrop with select2 and on select2 enable multiselect, on dep select add empty element.
https://github.com/kartik-v/dependent-dropdown/blob/master/js/dependent-dropdown.js#L22 

http://i63.fastpic.ru/big/2014/0926/69/617a051f91b1a51f7c6adef6d91efb69.jpg