### PR TITLE
Enhancement for ICU format conversion for DatePicker/DateTimePicker

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,3 +1,8 @@
+version 3.1.0
+**Date:** 09-Oct-2014
+
+1. enh: If DatePicker/DateTimePicker pluginOption['format'] isn't configured it takes format from Yii formatter according to app's language setting.
+
 version 3.0.0
 =============
 **Date:** 08-Oct-2014

--- a/DatePicker.php
+++ b/DatePicker.php
@@ -10,6 +10,7 @@ namespace kartik\widgets;
 
 use Yii;
 use yii\helpers\Html;
+use yii\helpers\FormatConverter;
 use yii\helpers\ArrayHelper;
 use yii\base\InvalidConfigException;
 use kartik\datecontrol\DateControl;
@@ -130,7 +131,15 @@ class DatePicker extends InputWidget
             throw new InvalidConfigException("The 'attribute2' property must be set for a 'range' type markup and a defined 'form' property.");
         }
         $this->initLanguage();
-        if ($this->convertFormat && isset($this->pluginOptions['format'])) {
+        if (!isset($this->pluginOptions['format'])){
+            $format = Yii::$app->formatter->dateFormat;
+            if (strncmp($this->dateFormat, 'php:', 4) === 0) {
+                $this->pluginOptions['format'] = static::convertDateFormat(substr($format, 4));
+            } else {
+                $format = FormatConverter::convertDateIcuToPhp($format, 'date');
+                $this->pluginOptions['format'] = static::convertDateFormat($format);
+            }
+        } elseif ($this->convertFormat && isset($this->pluginOptions['format'])) {
             $this->pluginOptions['format'] = static::convertDateFormat($this->pluginOptions['format']);
         }
         $this->_id = ($this->type == self::TYPE_INPUT) ? 'jQuery("#' . $this->options['id'] . '")' : 'jQuery("#' . $this->options['id'] . '").parent()';

--- a/DateTimePicker.php
+++ b/DateTimePicker.php
@@ -11,6 +11,7 @@ namespace kartik\widgets;
 use Yii;
 use yii\helpers\Html;
 use yii\helpers\ArrayHelper;
+use yii\helpers\FormatConverter;
 use yii\base\InvalidConfigException;
 
 /**
@@ -89,7 +90,15 @@ class DateTimePicker extends InputWidget
             throw new InvalidConfigException("Invalid value for the property 'type'. Must be an integer between 1 and 4.");
         }
         $this->initLanguage();
-        if ($this->convertFormat && isset($this->pluginOptions['format'])) {
+        if (!isset($this->pluginOptions['format'])){
+            $format = Yii::$app->formatter->datetimeFormat;
+            if (strncmp($this->dateFormat, 'php:', 4) === 0) {
+                $this->pluginOptions['format'] = static::convertDateFormat(substr($format, 4));
+            } else {
+                $format = FormatConverter::convertDateIcuToPhp($format, 'datetime');
+                $this->pluginOptions['format'] = static::convertDateFormat($format);
+            }
+        } elseif ($this->convertFormat && isset($this->pluginOptions['format'])) {
             $this->pluginOptions['format'] = static::convertDateFormat($this->pluginOptions['format']);
         }
         $this->_id = ($this->type == self::TYPE_INPUT) ? 'jQuery("#' . $this->options['id'] . '")' : 'jQuery("#' . $this->options['id'] . '").parent()';


### PR DESCRIPTION
DatePicker and DateTimePicker widgets enhanced with same functionality as in DateControl. If pluginOption['format'] isn't configured then it takes format from Yii Formatter. It is converted from ICU to PHP and then from PHP to boostrap DP format.
